### PR TITLE
Download a dataset's resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current (in progress)
 
+- Allow to download a dataset's resources [#8](https://github.com/datagouv/datagouv_client/pull/8)
 - Allow to download a resource [#7](https://github.com/datagouv/datagouv_client/pull/7)
 - Allow to prevent fetch on object creation [#6](https://github.com/datagouv/datagouv_client/pull/6)
 - Allow to update static resources' files [#4](https://github.com/datagouv/datagouv_client/pull/4)

--- a/README.md
+++ b/README.md
@@ -31,10 +31,18 @@ for res in dataset.resources:
 # if you are only interested in a specific resource
 resource = Resource("f868cca6-8da1-4369-a78d-47463f19a9a3")  # you can find a resource's id in its `Métadonnées` tab
 print(resource)
+
 # you can also access a dataset from one of its resources
 d = resource.dataset()  # NB: this is a method, and returns an instance of Dataset
+
 # you can also download a resource locally (NB: make sure to create the parent folders upstream)
 resource.download("./file.csv")  # this saves the resource in your working directory as "file.csv"
+
+# and a subset or all resources of a dataset (NB: make sure to create the parent folders upstream)
+d.download_resources(
+    folder="data",  # if not specified, saves them into your working directory
+    resources_types=["main", "documentation"],  # default is only main resources
+)
 ```
 
 ### Interacting with objects online

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ d = resource.dataset()  # NB: this is a method, and returns an instance of Datas
 resource.download("./file.csv")  # this saves the resource in your working directory as "file.csv"
 
 # and a subset or all resources of a dataset (NB: make sure to create the parent folders upstream)
+# the files are named `resource_id.format` (for instance f868cca6-8da1-4369-a78d-47463f19a9a3.csv)
 d.download_resources(
     folder="data",  # if not specified, saves them into your working directory
     resources_types=["main", "documentation"],  # default is only main resources

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ print(resource)
 # you can also access a dataset from one of its resources
 d = resource.dataset()  # NB: this is a method, and returns an instance of Dataset
 # you can also download a resource locally (NB: make sure to create the parent folders upstream)
-resource.download("file.csv")  # this saves the resource in your working directory as "file.csv"
+resource.download("./file.csv")  # this saves the resource in your working directory as "file.csv"
 ```
 
 ### Interacting with objects online

--- a/datagouv/dataset.py
+++ b/datagouv/dataset.py
@@ -45,14 +45,15 @@ class Dataset(BaseObject, ResourceCreator):
             for r in resources
         ]
 
-    def download_resources(self, folder: str | None = None, resources_types: list = ["main"]):
+    def download_resources(
+        self, folder: str | None = None, resources_types: list = ["main"]
+    ):
         for res in self.resources:
             if res.type in resources_types:
                 logging.info(f"Downloading {res.url}")
                 res.download(
                     path=(
-                        os.path.join(folder, res.url.split("/")[-1])
-                        if folder else None
+                        os.path.join(folder, res.url.split("/")[-1]) if folder else None
                     ),
                 )
 

--- a/datagouv/dataset.py
+++ b/datagouv/dataset.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from .base_object import BaseObject, Creator, assert_auth
 from .client import Client
@@ -43,6 +44,17 @@ class Dataset(BaseObject, ResourceCreator):
             )
             for r in resources
         ]
+
+    def download_resources(self, folder: str | None = None, resources_types: list = ["main"]):
+        for res in self.resources:
+            if res.type in resources_types:
+                logging.info(f"Downloading {res.url}")
+                res.download(
+                    path=(
+                        os.path.join(folder, res.url.split("/")[-1])
+                        if folder else None
+                    ),
+                )
 
 
 class DatasetCreator(Creator):

--- a/datagouv/dataset.py
+++ b/datagouv/dataset.py
@@ -53,7 +53,9 @@ class Dataset(BaseObject, ResourceCreator):
                 logging.info(f"Downloading {res.url}")
                 res.download(
                     path=(
-                        os.path.join(folder, f"{res.id}.{res.format}") if folder else None
+                        os.path.join(folder, f"{res.id}.{res.format}")
+                        if folder
+                        else None
                     ),
                 )
 

--- a/datagouv/dataset.py
+++ b/datagouv/dataset.py
@@ -46,14 +46,14 @@ class Dataset(BaseObject, ResourceCreator):
         ]
 
     def download_resources(
-        self, folder: str | None = None, resources_types: list = ["main"]
+        self, folder: str | None = None, resources_types: list[str] = ["main"]
     ):
         for res in self.resources:
             if res.type in resources_types:
                 logging.info(f"Downloading {res.url}")
                 res.download(
                     path=(
-                        os.path.join(folder, res.url.split("/")[-1]) if folder else None
+                        os.path.join(folder, f"{res.id}.{res.format}") if folder else None
                     ),
                 )
 

--- a/datagouv/resource.py
+++ b/datagouv/resource.py
@@ -13,6 +13,7 @@ class Resource(BaseObject):
         "description",
         "filetype",
         "filesize",
+        "format",
         "internal",
         "last_modified",
         "schema",
@@ -75,7 +76,7 @@ class Resource(BaseObject):
 
     def download(self, path: str | None = None, chunk_size: int = 8192, **kwargs):
         if path is None:
-            path = self.url.split("/")[-1]
+            path = f"{self.id}.{self.format}"
         with requests.get(self.url, stream=True, **kwargs) as r:
             r.raise_for_status()
             with open(path, "wb") as f:

--- a/datagouv/resource.py
+++ b/datagouv/resource.py
@@ -73,7 +73,9 @@ class Resource(BaseObject):
 
         return Dataset(self.dataset_id, _client=self._client)
 
-    def download(self, path: str, chunk_size: int = 8192, **kwargs):
+    def download(self, path: str | None = None, chunk_size: int = 8192, **kwargs):
+        if path is None:
+            path = self.url.split("/")[-1]
         with requests.get(self.url, stream=True, **kwargs) as r:
             r.raise_for_status()
             with open(path, "wb") as f:

--- a/tests/dataset_metadata.json
+++ b/tests/dataset_metadata.json
@@ -468,7 +468,7 @@
         "preview_url": "https://explore.data.gouv.fr/fr/resources/1ac234c7-1da4-49cf-a122-646b21d64b43",
         "schema": null,
         "title": "export-tag-20250407-061529.csv",
-        "type": "main",
+        "type": "documentation",
         "url": "https://static.data.gouv.fr/resources/catalogue-des-donnees-de-data-gouv-fr/20250407-061529/export-tag-20250407-061529.csv"
       }
     ],

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -93,14 +93,21 @@ def test_resource_no_fetch():
     assert r.uri
 
 
-def test_resource_download(remote_resource_api1_call):
+@pytest.mark.parametrize(
+    "file_name",
+    [
+        "my_file.csv",
+        None,
+    ],
+)
+def test_resource_download(remote_resource_api1_call, file_name):
     r = Client().resource(RESOURCE_ID, dataset_id=DATASET_ID)
     with requests_mock.Mocker() as m:
         m.get(r.url, content=b"a,b,c\n1,2,3")
-        file_name = "my_file.csv"
         r.download(file_name)
-        with open(file_name, "r") as f:
+        local_name = file_name or f"{r.id}.{r.format}"
+        with open(local_name, "r") as f:
             rows = f.readlines()
         assert rows[0] == "a,b,c\n"
         assert rows[1] == "1,2,3"
-    os.remove(file_name)
+    os.remove(local_name)


### PR DESCRIPTION
Thoughts:
- as it stands, if two resources of a dataset share the same file name, only the latest download will remain (the others will have been erased)
- we could also have something like `my_dataset.download_resources(pattern="*.csv")` to allow to target specific resources (but then should it target the title or the url?)