### PR TITLE
feat: accept pathlib.Path type as download arguments, and use pathlib.Path internally to handle file paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `preview_url` field to resources' attributes [#18](https://github.com/datagouv/csv-detective/pull/18)
 - Pass the organization's client to its datasets [#19](https://github.com/datagouv/csv-detective/pull/19)
 - Switch to `httpx` [#21](https://github.com/datagouv/csv-detective/pull/21)
+- Accept `Path` type as download arguments, and use `Path` internally to handle file paths [#24](https://github.com/datagouv/datagouv_client/pull/24)
 
 ## 0.1.3 (2025-08-21)
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ print(resource)
 # you can also access a dataset from one of its resources
 d = resource.dataset()  # **Note:** this is a method, and returns an instance of Dataset
 
-# you can also download a resource locally (**Note:** make sure to create the parent folders upstream)
+# you can also download a resource locally (**Note:** if it doesn't exist, parent path will be created)
 resource.download("./file.csv")  # this saves the resource in your working directory as "file.csv"
 
-# and a subset or all resources of a dataset (**Note:** make sure to create the parent folders upstream)
+# and a subset or all resources of a dataset (**Note:** if it doesn't exist, parent path will be created)
 # the files are named `resource_id.format` (for instance f868cca6-8da1-4369-a78d-47463f19a9a3.csv)
 d.download_resources(
     folder="data",  # if not specified, saves them into your working directory

--- a/datagouv/dataset.py
+++ b/datagouv/dataset.py
@@ -67,6 +67,8 @@ class Dataset(BaseObject, ResourceCreator):
             if res.type in resources_types:
                 if folder is not None:
                     folder_path = Path(folder) if isinstance(folder, str) else folder
+                    # Ensure the folder exists
+                    folder_path.mkdir(parents=True, exist_ok=True)
                     path = folder_path / f"{res.id}.{res.format}"
                 else:
                     path = None

--- a/datagouv/dataset.py
+++ b/datagouv/dataset.py
@@ -1,5 +1,5 @@
 import logging
-import os
+from pathlib import Path
 
 from .base_object import BaseObject, Creator, assert_auth
 from .client import Client
@@ -60,13 +60,18 @@ class Dataset(BaseObject, ResourceCreator):
             else None
         )
 
-    def download_resources(self, folder: str | None = None, resources_types: list[str] = ["main"]):
+    def download_resources(
+        self, folder: Path | str | None = None, resources_types: list[str] = ["main"]
+    ):
         for res in self.resources:
             if res.type in resources_types:
                 logging.info(f"Downloading {res.url}")
-                res.download(
-                    path=(os.path.join(folder, f"{res.id}.{res.format}") if folder else None),
-                )
+                if folder is not None:
+                    folder_path = Path(folder) if isinstance(folder, str) else folder
+                    path = folder_path / f"{res.id}.{res.format}"
+                else:
+                    path = None
+                res.download(path=path)
 
 
 class DatasetCreator(Creator):

--- a/datagouv/dataset.py
+++ b/datagouv/dataset.py
@@ -65,12 +65,12 @@ class Dataset(BaseObject, ResourceCreator):
     ):
         for res in self.resources:
             if res.type in resources_types:
-                logging.info(f"Downloading {res.url}")
                 if folder is not None:
                     folder_path = Path(folder) if isinstance(folder, str) else folder
                     path = folder_path / f"{res.id}.{res.format}"
                 else:
                     path = None
+                logging.info(f"Downloading {res.url}")
                 res.download(path=path)
 
 

--- a/datagouv/resource.py
+++ b/datagouv/resource.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 
 import httpx
 
@@ -76,9 +77,13 @@ class Resource(BaseObject):
 
         return Dataset(self.dataset_id, _client=self._client)
 
-    def download(self, path: str | None = None, chunk_size: int = 8192, **kwargs):
+    def download(self, path: Path | str | None = None, chunk_size: int = 8192, **kwargs):
         if path is None:
-            path = f"{self.id}.{self.format}"
+            path = Path(f"{self.id}.{self.format}")
+        if isinstance(path, str):
+            path = Path(path)
+        # Ensure parent directory exists
+        path.parent.mkdir(parents=True, exist_ok=True)
         with httpx.stream("GET", self.url, **kwargs) as r:
             r.raise_for_status()
             with open(path, "wb") as f:


### PR DESCRIPTION
- Accept `Path` types along with `str` in methods `Resource.download` and `Dataset.download_resources`.

That doesn't change the behaviour per se, as internally Python converts between the two when possible, but it will avoid any warning in IDEs and type checkers.

- Automatic directory creation for `Resource.download`: If you pass `Path("data/subfolder/file.csv")` and the data/subfolder directories don't exist, they'll be created automatically

- Use `pathlib.Path` internally for file paths in methods `Resource.download` and `Dataset.download_resources`. `Path` has several advantages over `str` and `os` operations:
    - Cleaner error messages: If there are permission issues or other path-related problems, the error handling is more explicit
    - Cross-platform compatibility: Path objects handle path separators correctly on different operating systems
    - Future extensibility: Easier to add path-related features later
    - More explicit: Makes the intent clearer