### PR TITLE
Enable to create a static resource from a URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Enable creating a static resource from a URL [#26](https://github.com/datagouv/csv-detective/pull/26)
 
 ## 0.1.4 (2025-09-04)
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,18 @@ resource = dataset.create_remote(
 # to update the file of a static resource
 resource.update({"title": "New title"}, file_to_upload="path/to/your/new_file.txt")
 ```
+
+You can also create a static resource from a file using its URL by setting `from_url=True`, in which case the `file_name` and `mime` arguments are required:
+```python
+resource = dataset.create_static(
+    file_to_upload="https://wesite.org/path/to/your/file.txt",
+    payload={"title": "New static resource"},
+    from_url=True,
+    file_name="file.txt",
+    mime="text/plain",
+)  # this creates a static resource with the values you specified, and instantiates a Resource
+```
+
 > **Note:** If you are not planning to use an object's attributes, you may prevent the initial API call using `fetch=False`, in order not to unnecessarily ping the API.
 ```python
 dataset = client.dataset("5d13a8b6634f41070a43dff3", fetch=False)

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -54,7 +54,7 @@ def test_resource_attributes_and_methods(static_resource_api2_call):
 def test_authentification_assertion():
     client = Client()
     with pytest.raises(PermissionError):
-        client.resource().create_static({"path": "path"}, {"title": "Titre"}, DATASET_ID)
+        client.resource().create_static("path/to/file.csv", {"title": "Titre"}, DATASET_ID)
     with pytest.raises(PermissionError):
         client.resource().create_remote({"url": "url", "title": "Titre"}, DATASET_ID)
     r_from_response = Resource(
@@ -111,3 +111,14 @@ def test_resource_download(remote_resource_api1_call, file_name, httpx_mock):
     assert rows[0] == "a,b,c\n"
     assert rows[1] == "1,2,3"
     os.remove(local_name)
+
+
+def test_create_static_from_url():
+    client = Client(api_key="SUPER_SECRET")
+    with pytest.raises(ValueError):
+        client.resource().create_static(
+            "https://example.com/file.csv",
+            {"title": "Titre"},
+            DATASET_ID,
+            from_url=True,
+        )


### PR DESCRIPTION
We could also retrieve/build `file_name` and `mime` from the URL's headers, but it sounds safer to ask the user to fill them in, idk 🤔 