### PR TITLE
Refactor syntaxes (inspired from topics), add tests and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - feat: add Topic [#27](https://github.com/datagouv/datagouv_client/pull/27)
+- Replace relevant methods with attributes (/!\ breaking changes) and add tests [#27](https://github.com/datagouv/datagouv_client/pull/28)
 
 ## 0.1.4 (2025-09-04)
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ resource = Resource("f868cca6-8da1-4369-a78d-47463f19a9a3")  # you can find a re
 print(resource)
 
 # you can also access a dataset from one of its resources
-d = resource.dataset()  # **Note:** this is a method, and returns an instance of Dataset
+d = resource.dataset  # this returns an instance of Dataset
 
 # you can also download a resource locally (**Note:** if it doesn't exist, parent path will be created)
 resource.download("./file.csv")  # this saves the resource in your working directory as "file.csv"
@@ -74,8 +74,8 @@ d.download_resources(
 
 
 organization = Organization("646b7187b50b2a93b1ae3d45")  # you can find an organization's id in the `Informations` tab of its landing page, in "Informations techniques"
-# you can loop through the organization's datasets
-for dat in organization.datasets():
+# you can loop through the organization's datasets, which are Dataset instances
+for dat in organization.datasets:
     print(f"{dat.title} has {len(dat.resources)} resources")
 ```
 

--- a/datagouv/base_object.py
+++ b/datagouv/base_object.py
@@ -19,7 +19,7 @@ class BaseObject:
     uri: str
     _attributes: list[str] = []
 
-    def __init__(self, id: str | None = None, _client: Client = Client()):
+    def __init__(self, id: str, _client: Client = Client()):
         self.id = id
         self._client = _client
         self._base_metrics_url = (

--- a/datagouv/base_object.py
+++ b/datagouv/base_object.py
@@ -75,7 +75,8 @@ class BaseObject:
         assert_auth(self._client)
         logging.info(f"🚮 Deleting extras {payload} for {self.uri}")
         r = self._client.session.delete(
-            self.uri.replace("api/1", "api/2") + "extras/", json=payload  # pyright: ignore[reportCallIssue] udata handles body on DELETE
+            self.uri.replace("api/1", "api/2") + "extras/",
+            json=payload,  # pyright: ignore[reportCallIssue] udata handles body on DELETE
         )
         r.raise_for_status()
         self.refresh()

--- a/datagouv/client.py
+++ b/datagouv/client.py
@@ -1,4 +1,3 @@
-import re
 from typing import Iterator
 
 import httpx

--- a/datagouv/dataset.py
+++ b/datagouv/dataset.py
@@ -28,7 +28,7 @@ class Dataset(BaseObject, ResourceCreator):
 
     def __init__(
         self,
-        id: str | None = None,
+        id: str,
         fetch: bool = True,
         _client: Client = Client(),
         _from_response: dict | None = None,

--- a/datagouv/organization.py
+++ b/datagouv/organization.py
@@ -23,7 +23,7 @@ class Organization(BaseObject):
 
     def __init__(
         self,
-        id: str | None = None,
+        id: str,
         fetch: bool = True,
         _client: Client = Client(),
         _from_response: dict | None = None,

--- a/datagouv/organization.py
+++ b/datagouv/organization.py
@@ -8,6 +8,7 @@ from .retry import simple_connection_retry
 
 
 class Organization(BaseObject):
+    _datasets: list[Dataset] | None = None
     _attributes = [
         "badges",
         "business_number_id",
@@ -34,9 +35,21 @@ class Organization(BaseObject):
         if fetch or _from_response:
             self.refresh(_from_response=_from_response)
 
+    def refresh(self, _from_response: dict | None = None):
+        metadata = super().refresh(_from_response)
+        self._datasets = None
+        return metadata
+
+    @property
     def datasets(self) -> Iterator[Dataset]:
-        for item in self._client.get_all_from_api_query(f"api/1/organizations/{self.id}/datasets/"):
-            yield Dataset(item["id"], _client=self._client, _from_response=item)
+        if self._datasets is None:
+            self._datasets = [
+                Dataset(item["id"], _client=self._client, _from_response=item)
+                for item in self._client.get_all_from_api_query(
+                    f"api/1/organizations/{self.id}/datasets/"
+                )
+            ]
+        yield from self._datasets
 
     def create_dataset(self, payload: dict) -> Dataset:
         # we don't simply heritate from DatasetCreator to have a different method name

--- a/datagouv/resource.py
+++ b/datagouv/resource.py
@@ -9,8 +9,7 @@ from .retry import simple_connection_retry
 
 
 class Resource(BaseObject):
-    from .dataset import Dataset
-    _dataset: Dataset | None = None
+    _dataset = None
     _attributes = [
         "checksum",
         "created_at",

--- a/datagouv/resource.py
+++ b/datagouv/resource.py
@@ -81,6 +81,7 @@ class Resource(BaseObject):
         # it makes more sense that a dataset has its resources instantiated at init
         # so resources must have dataset as a separate method
         from .dataset import Dataset
+
         if self._dataset is None:
             dataset = Dataset(self.dataset_id, _client=self._client)
             self._dataset = dataset
@@ -155,7 +156,9 @@ class ResourceCreator(Creator):
         r = self._client.session.post(url, json=payload)
         r.raise_for_status()
         metadata = r.json()
-        return Resource(metadata["id"], dataset_id=dataset_id, _client=self._client, _from_response=metadata)
+        return Resource(
+            metadata["id"], dataset_id=dataset_id, _client=self._client, _from_response=metadata
+        )
 
     @simple_connection_retry
     def create_static(

--- a/datagouv/resource.py
+++ b/datagouv/resource.py
@@ -155,7 +155,7 @@ class ResourceCreator(Creator):
         r = self._client.session.post(url, json=payload)
         r.raise_for_status()
         metadata = r.json()
-        return Resource(metadata["id"], _client=self._client, _from_response=metadata)
+        return Resource(metadata["id"], dataset_id=dataset_id, _client=self._client, _from_response=metadata)
 
     @simple_connection_retry
     def create_static(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 
 from datagouv.client import Client
 
@@ -100,7 +101,10 @@ def test_get_all(args):
         # Test deeply nested key
         (
             [
-                {"data": [{"id": 1}], "meta": {"pagination": {"next": "https://api.example.com/page2"}}},
+                {
+                    "data": [{"id": 1}],
+                    "meta": {"pagination": {"next": "https://api.example.com/page2"}},
+                },
                 {"data": [{"id": 2}], "meta": {"pagination": {"next": None}}},
             ],
             "meta.pagination.next",
@@ -119,7 +123,7 @@ def test_get_all_from_api_query_pagination(responses, next_page_key, expected_da
         mock_response.raise_for_status.return_value = None
         mock_responses.append(mock_response)
 
-    with patch.object(client.session, 'get', side_effect=mock_responses):
+    with patch.object(client.session, "get", side_effect=mock_responses):
         result = list(client.get_all_from_api_query("api/test", next_page=next_page_key))
 
     assert result == expected_data
@@ -132,10 +136,10 @@ def test_get_all_from_api_query_with_mask():
     mock_response.json.return_value = {"data": [{"id": 1, "title": "test"}], "next_page": None}
     mock_response.raise_for_status.return_value = None
 
-    with patch.object(client.session, 'get', return_value=mock_response) as mock_get:
+    with patch.object(client.session, "get", return_value=mock_response) as mock_get:
         list(client.get_all_from_api_query("api/test", mask="data{id,title}"))
 
         # Verify the mask was added to headers
         mock_get.assert_called_once()
-        headers = mock_get.call_args[1]['headers']
-        assert headers['X-fields'] == "data{id,title},next_page"
+        headers = mock_get.call_args[1]["headers"]
+        assert headers["X-fields"] == "data{id,title},next_page"

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -76,7 +76,7 @@ def test_datasets(httpx_mock):
         json={"data": [dataset_metadata], "next_page": None},
     )
     o_from_response = Organization(ORGANIZATION_ID, _from_response=organization_metadata)
-    datasets = list(o_from_response.datasets())
+    datasets = list(o_from_response.datasets)
     assert len(datasets) == 1
     assert isinstance(datasets[0], Dataset)
 

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -71,7 +71,7 @@ def test_dataset(dataset_api_call):
     r_from_response = Resource(
         RESOURCE_ID, dataset_id=DATASET_ID, _from_response=resource_metadata_api1
     )
-    assert isinstance(r_from_response.dataset(), Dataset)
+    assert isinstance(r_from_response.dataset, Dataset)
 
 
 def test_upload_file_into_remote(remote_resource_api2_call):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -131,7 +131,7 @@ def test_resource_download(remote_resource_api1_call, file_name, httpx_mock):
                 "dataset_id": DATASET_ID,
             },
         ),
-    ]
+    ],
 )
 def test_resource_create(httpx_mock, method, kwargs):
     # Mock the API response for resource creation

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -111,3 +111,95 @@ def test_resource_download(remote_resource_api1_call, file_name, httpx_mock):
     assert rows[0] == "a,b,c\n"
     assert rows[1] == "1,2,3"
     os.remove(local_name)
+
+
+@pytest.mark.parametrize(
+    "method,kwargs",
+    [
+        (
+            "create_static",
+            {
+                "payload": {"title": "New static resource"},
+                "file_to_upload": "tests/resource_metadata_api1.json",
+                "dataset_id": DATASET_ID,
+            },
+        ),
+        (
+            "create_remote",
+            {
+                "payload": {"title": "New remote resource"},
+                "dataset_id": DATASET_ID,
+            },
+        ),
+    ]
+)
+def test_resource_create(httpx_mock, method, kwargs):
+    # Mock the API response for resource creation
+    httpx_mock.add_response(
+        method="POST",
+        url=(
+            f"https://www.data.gouv.fr/api/1/datasets/{DATASET_ID}/"
+            + ("resources/" if "remote" in method else "upload/")
+        ),
+        json=resource_metadata_api1,
+        status_code=201,
+    )
+    if "static" in method:
+        httpx_mock.add_response(
+            method="PUT",
+            url=(
+                f"https://www.data.gouv.fr/api/1/datasets/{DATASET_ID}"
+                f"/resources/{resource_metadata_api1['id']}/"
+            ),
+            json=resource_metadata_api1,
+            status_code=200,
+        )
+
+    client = Client(api_key="test-api-key")
+
+    created_resource = getattr(client.resource(), method)(**kwargs)
+
+    assert isinstance(created_resource, Resource)
+    for attr in Resource._attributes:
+        assert getattr(created_resource, attr) == resource_metadata_api1[attr]
+
+
+def test_resource_update(static_resource_api2_call, httpx_mock):
+    updated_metadata = resource_metadata_api1.copy()
+    payload = {
+        "title": "Updated Resource Title",
+        "description": "Updated description",
+    }
+
+    client = Client(api_key="test-api-key")
+    resource = client.resource(RESOURCE_ID)
+
+    # Mock the update response
+    httpx_mock.add_response(
+        method="PUT",
+        url=f"https://www.data.gouv.fr/api/1/datasets/{resource.dataset_id}/resources/{resource.id}/",
+        json=updated_metadata | payload,
+        status_code=200,
+    )
+
+    response = resource.update(payload)
+
+    assert response.status_code == 200
+    for attr in payload.keys():
+        assert getattr(resource, attr) == payload[attr]
+
+
+def test_resource_delete(static_resource_api2_call, httpx_mock):
+    client = Client(api_key="test-api-key")
+    resource = client.resource(RESOURCE_ID)
+
+    # Mock the delete response
+    httpx_mock.add_response(
+        method="DELETE",
+        url=f"https://www.data.gouv.fr/api/1/datasets/{resource.dataset_id}/resources/{resource.id}/",
+        status_code=204,
+    )
+
+    response = resource.delete()
+
+    assert response.status_code == 204

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -101,8 +101,8 @@ def test_topic_create(httpx_mock):
     created_topic = topic_creator.create(payload)
 
     assert isinstance(created_topic, Topic)
-    assert created_topic.id == "68b6e6dbdac745f47d4ff6e0"
-    assert created_topic.name == "Impact des services publics numériques de la DGALN"
+    for attr in Topic._attributes:
+        assert getattr(created_topic, attr) == topic_metadata[attr]
 
 
 def test_topic_update(topic_api_call, httpx_mock):

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -86,7 +86,7 @@ def test_topic_create(httpx_mock):
         method="POST",
         url="https://www.data.gouv.fr/api/2/topics/",
         json=topic_metadata,
-        status_code=201
+        status_code=201,
     )
 
     client = Client(api_key="test-api-key")
@@ -95,7 +95,7 @@ def test_topic_create(httpx_mock):
     payload = {
         "name": "Test Topic",
         "description": "A test topic",
-        "private": False
+        "private": False,
     }
 
     created_topic = topic_creator.create(payload)
@@ -108,29 +108,26 @@ def test_topic_create(httpx_mock):
 def test_topic_update(topic_api_call, httpx_mock):
     # Mock the update response
     updated_metadata = topic_metadata.copy()
-    updated_metadata["name"] = "Updated Topic Name"
-    updated_metadata["description"] = "Updated description"
+    payload = {
+        "name": "Updated Topic Name",
+        "description": "Updated description"
+    }
 
     httpx_mock.add_response(
         method="PUT",
         url=f"https://www.data.gouv.fr/api/2/topics/{TOPIC_ID}/",
-        json=updated_metadata,
+        json=updated_metadata | payload,
         status_code=200
     )
 
     client = Client(api_key="test-api-key")
     topic = client.topic(TOPIC_ID)
 
-    payload = {
-        "name": "Updated Topic Name",
-        "description": "Updated description"
-    }
-
     response = topic.update(payload)
 
     assert response.status_code == 200
-    assert topic.name == "Updated Topic Name"
-    assert topic.description == "Updated description"
+    for attr in payload.keys():
+        assert getattr(topic, attr) == payload[attr]
 
 
 def test_topic_delete(topic_api_call, httpx_mock):
@@ -138,7 +135,7 @@ def test_topic_delete(topic_api_call, httpx_mock):
     httpx_mock.add_response(
         method="DELETE",
         url=f"https://www.data.gouv.fr/api/2/topics/{TOPIC_ID}/",
-        status_code=204
+        status_code=204,
     )
 
     client = Client(api_key="test-api-key")

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -108,16 +108,13 @@ def test_topic_create(httpx_mock):
 def test_topic_update(topic_api_call, httpx_mock):
     # Mock the update response
     updated_metadata = topic_metadata.copy()
-    payload = {
-        "name": "Updated Topic Name",
-        "description": "Updated description"
-    }
+    payload = {"name": "Updated Topic Name", "description": "Updated description"}
 
     httpx_mock.add_response(
         method="PUT",
         url=f"https://www.data.gouv.fr/api/2/topics/{TOPIC_ID}/",
         json=updated_metadata | payload,
-        status_code=200
+        status_code=200,
     )
 
     client = Client(api_key="test-api-key")


### PR DESCRIPTION
- some methods become attributes for more elegant flow (`resource.dataset`, `organization.datasets`) (this is a breaking change)
- adds tests for objects creation, update and deletion
- adding these tests made me spot a mistake when creating a remote resource (dataset_id was not passed on, therefore meaning a preventable API call)

This will be followed by a minor release I think