### PR TITLE
Better verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ for dat in organization.datasets:
 
 > **Note:** If you want to get objects from demo or dev, you must use a client:
 ```python
-from datagouv import Client, Dataset, Resource
+from datagouv import Client, Dataset
 
 dataset = Dataset("5d13a8b6634f41070a43dff3", _client=Client("demo"))
 ```
@@ -138,6 +138,7 @@ from datagouv import Client
 client = Client(
     environment="www",  # here you can set which platform the client will interact with, default is production
     api_key="MY_SECRET_API_KEY",  # your API key, that grants your rights on the platform
+    verbose=True,  # whether or not to display logs in the processes, default is True
 )
 ```
 > **Note:** You can find your API key on https://www.data.gouv.fr/fr/admin/me/ (don't forget to change the prefix to get the key from the right environment).

--- a/datagouv/base_object.py
+++ b/datagouv/base_object.py
@@ -47,7 +47,8 @@ class BaseObject:
     @simple_connection_retry
     def update(self, payload: dict) -> httpx.Response:
         assert_auth(self._client)
-        logging.info(f"🔁 Putting {self.uri} with {payload}")
+        if self._client.verbose:
+            logging.info(f"🔁 Putting {self.uri} with {payload}")
         r = self._client.session.put(self.uri, json=payload)
         r.raise_for_status()
         self.refresh(_from_response=r.json())
@@ -56,7 +57,8 @@ class BaseObject:
     @simple_connection_retry
     def delete(self) -> httpx.Response:
         assert_auth(self._client)
-        logging.info(f"🚮 Deleting {self.uri}")
+        if self._client.verbose:
+            logging.info(f"🚮 Deleting {self.uri}")
         r = self._client.session.delete(self.uri)
         r.raise_for_status()
         return r
@@ -64,7 +66,8 @@ class BaseObject:
     @simple_connection_retry
     def update_extras(self, payload: dict) -> httpx.Response:
         assert_auth(self._client)
-        logging.info(f"🔁 Putting {self.uri} with extras {payload}")
+        if self._client.verbose:
+            logging.info(f"🔁 Putting {self.uri} with extras {payload}")
         r = self._client.session.put(self.uri.replace("api/1", "api/2") + "extras/", json=payload)
         r.raise_for_status()
         self.refresh()
@@ -74,7 +77,8 @@ class BaseObject:
     def delete_extras(self, keys: list[str]) -> httpx.Response:
         """Convenience method"""
         assert_auth(self._client)
-        logging.info(f"🚮 Deleting extras {keys} for {self.uri}")
+        if self._client.verbose:
+            logging.info(f"🚮 Deleting extras {keys} for {self.uri}")
         r = self.update_extras({k: None for k in keys})
         r.raise_for_status()
         self.refresh()

--- a/datagouv/base_object.py
+++ b/datagouv/base_object.py
@@ -38,7 +38,10 @@ class BaseObject:
             metadata = _from_response
         else:
             r = self._client.session.get(self.uri)
-            r.raise_for_status()
+            try:
+                r.raise_for_status()
+            except Exception as e:
+                raise httpx.HTTPStatusError(r.text) from e
             metadata = r.json()
         for a in self._attributes:
             setattr(self, a, metadata.get(a))
@@ -50,7 +53,10 @@ class BaseObject:
         if self._client.verbose:
             logging.info(f"🔁 Putting {self.uri} with {payload}")
         r = self._client.session.put(self.uri, json=payload)
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except Exception as e:
+            raise httpx.HTTPStatusError(r.text) from e
         self.refresh(_from_response=r.json())
         return r
 
@@ -60,7 +66,10 @@ class BaseObject:
         if self._client.verbose:
             logging.info(f"🚮 Deleting {self.uri}")
         r = self._client.session.delete(self.uri)
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except Exception as e:
+            raise httpx.HTTPStatusError(r.text) from e
         return r
 
     @simple_connection_retry
@@ -69,7 +78,10 @@ class BaseObject:
         if self._client.verbose:
             logging.info(f"🔁 Putting {self.uri} with extras {payload}")
         r = self._client.session.put(self.uri.replace("api/1", "api/2") + "extras/", json=payload)
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except Exception as e:
+            raise httpx.HTTPStatusError(r.text) from e
         self.refresh()
         return r
 
@@ -80,7 +92,10 @@ class BaseObject:
         if self._client.verbose:
             logging.info(f"🚮 Deleting extras {keys} for {self.uri}")
         r = self.update_extras({k: None for k in keys})
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except Exception as e:
+            raise httpx.HTTPStatusError(r.text) from e
         self.refresh()
         return r
 

--- a/datagouv/base_object.py
+++ b/datagouv/base_object.py
@@ -41,7 +41,7 @@ class BaseObject:
             try:
                 r.raise_for_status()
             except Exception as e:
-                raise httpx.HTTPStatusError(r.text) from e
+                raise Exception(r.text) from e
             metadata = r.json()
         for a in self._attributes:
             setattr(self, a, metadata.get(a))
@@ -56,7 +56,7 @@ class BaseObject:
         try:
             r.raise_for_status()
         except Exception as e:
-            raise httpx.HTTPStatusError(r.text) from e
+            raise Exception(r.text) from e
         self.refresh(_from_response=r.json())
         return r
 
@@ -69,7 +69,7 @@ class BaseObject:
         try:
             r.raise_for_status()
         except Exception as e:
-            raise httpx.HTTPStatusError(r.text) from e
+            raise Exception(r.text) from e
         return r
 
     @simple_connection_retry
@@ -81,7 +81,7 @@ class BaseObject:
         try:
             r.raise_for_status()
         except Exception as e:
-            raise httpx.HTTPStatusError(r.text) from e
+            raise Exception(r.text) from e
         self.refresh()
         return r
 
@@ -95,7 +95,7 @@ class BaseObject:
         try:
             r.raise_for_status()
         except Exception as e:
-            raise httpx.HTTPStatusError(r.text) from e
+            raise Exception(r.text) from e
         self.refresh()
         return r
 

--- a/datagouv/client.py
+++ b/datagouv/client.py
@@ -9,12 +9,20 @@ if TYPE_CHECKING:
 class Client:
     _envs = ["www", "demo", "dev"]
 
-    def __init__(self, environment: str = "www", api_key: str | None = None, **kwargs):
+    def __init__(
+        self,
+        environment: str = "www",
+        api_key: str | None = None,
+        *,
+        verbose: bool = True,
+        **kwargs,
+    ):
         if environment not in self._envs:
             raise ValueError(f"`environment` must be in {self._envs}")
         self.base_url = f"https://{environment}.data.gouv.fr"
         self.session = httpx.Client(**({"timeout": 15} | kwargs))
         self.environment = environment
+        self.verbose = verbose
         self._authenticated = False
         if api_key:
             self._authenticated = True

--- a/datagouv/client.py
+++ b/datagouv/client.py
@@ -99,7 +99,7 @@ class Client:
         try:
             r.raise_for_status()
         except Exception as e:
-            raise httpx.HTTPStatusError(r.text) from e
+            raise Exception(r.text) from e
         for elem in r.json()["data"]:
             yield cast_elem(elem, self, cast_as)
         next_url = get_link_next_page(r.json(), next_page)
@@ -108,7 +108,7 @@ class Client:
             try:
                 r.raise_for_status()
             except Exception as e:
-                raise httpx.HTTPStatusError(r.text) from e
+                raise Exception(r.text) from e
             for data in r.json()["data"]:
                 yield cast_elem(data, self, cast_as)
             next_url = get_link_next_page(r.json(), next_page)

--- a/datagouv/client.py
+++ b/datagouv/client.py
@@ -96,13 +96,19 @@ class Client:
             base_query if _ignore_base_url else f"{self.base_url}/{base_query}",
             headers=headers,
         )
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except Exception as e:
+            raise httpx.HTTPStatusError(r.text) from e
         for elem in r.json()["data"]:
             yield cast_elem(elem, self, cast_as)
         next_url = get_link_next_page(r.json(), next_page)
         while next_url:
             r = self.session.get(next_url, headers=headers)
-            r.raise_for_status()
+            try:
+                r.raise_for_status()
+            except Exception as e:
+                raise httpx.HTTPStatusError(r.text) from e
             for data in r.json()["data"]:
                 yield cast_elem(data, self, cast_as)
             next_url = get_link_next_page(r.json(), next_page)

--- a/datagouv/dataset.py
+++ b/datagouv/dataset.py
@@ -1,8 +1,6 @@
 import logging
 from pathlib import Path
 
-import httpx
-
 from .base_object import BaseObject, Creator, assert_auth
 from .client import Client
 from .resource import Resource, ResourceCreator
@@ -109,6 +107,6 @@ class DatasetCreator(Creator):
         try:
             r.raise_for_status()
         except Exception as e:
-            raise httpx.HTTPStatusError(r.text) from e
+            raise Exception(r.text) from e
         metadata = r.json()
         return Dataset(metadata["id"], _client=self._client, _from_response=metadata)

--- a/datagouv/dataset.py
+++ b/datagouv/dataset.py
@@ -1,6 +1,8 @@
 import logging
 from pathlib import Path
 
+import httpx
+
 from .base_object import BaseObject, Creator, assert_auth
 from .client import Client
 from .resource import Resource, ResourceCreator
@@ -104,6 +106,9 @@ class DatasetCreator(Creator):
         if self._client.verbose:
             logging.info(f"Creating dataset '{payload['title']}'")
         r = self._client.session.post(f"{self._client.base_url}/api/1/datasets/", json=payload)
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except Exception as e:
+            raise httpx.HTTPStatusError(r.text) from e
         metadata = r.json()
         return Dataset(metadata["id"], _client=self._client, _from_response=metadata)

--- a/datagouv/dataset.py
+++ b/datagouv/dataset.py
@@ -92,7 +92,8 @@ class Dataset(BaseObject, ResourceCreator):
                     path = folder_path / f"{res.id}.{res.format}"
                 else:
                     path = None
-                logging.info(f"Downloading {res.url}")
+                if self._client.verbose:
+                    logging.info(f"Downloading {res.url}")
                 res.download(path=path)
 
 
@@ -100,7 +101,8 @@ class DatasetCreator(Creator):
     @simple_connection_retry
     def create(self, payload: dict) -> Dataset:
         assert_auth(self._client)
-        logging.info(f"Creating dataset '{payload['title']}'")
+        if self._client.verbose:
+            logging.info(f"Creating dataset '{payload['title']}'")
         r = self._client.session.post(f"{self._client.base_url}/api/1/datasets/", json=payload)
         r.raise_for_status()
         metadata = r.json()

--- a/datagouv/organization.py
+++ b/datagouv/organization.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Iterator
 
+import httpx
+
 from .base_object import BaseObject, Creator, assert_auth
 from .client import Client
 from .dataset import Dataset, DatasetCreator
@@ -75,6 +77,9 @@ class OrganizationCreator(Creator):
         if self._client.verbose:
             logging.info(f"Creating organization '{payload['name']}'")
         r = self._client.session.post(f"{self._client.base_url}/api/1/organizations/", json=payload)
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except Exception as e:
+            raise httpx.HTTPStatusError(r.text) from e
         metadata = r.json()
         return Organization(metadata["id"], _client=self._client, _from_response=metadata)

--- a/datagouv/organization.py
+++ b/datagouv/organization.py
@@ -1,8 +1,6 @@
 import logging
 from typing import Iterator
 
-import httpx
-
 from .base_object import BaseObject, Creator, assert_auth
 from .client import Client
 from .dataset import Dataset, DatasetCreator
@@ -80,6 +78,6 @@ class OrganizationCreator(Creator):
         try:
             r.raise_for_status()
         except Exception as e:
-            raise httpx.HTTPStatusError(r.text) from e
+            raise Exception(r.text) from e
         metadata = r.json()
         return Organization(metadata["id"], _client=self._client, _from_response=metadata)

--- a/datagouv/organization.py
+++ b/datagouv/organization.py
@@ -72,7 +72,8 @@ class OrganizationCreator(Creator):
     @simple_connection_retry
     def create(self, payload: dict) -> Organization:
         assert_auth(self._client)
-        logging.info(f"Creating organization '{payload['name']}'")
+        if self._client.verbose:
+            logging.info(f"Creating organization '{payload['name']}'")
         r = self._client.session.post(f"{self._client.base_url}/api/1/organizations/", json=payload)
         r.raise_for_status()
         metadata = r.json()

--- a/datagouv/resource.py
+++ b/datagouv/resource.py
@@ -69,7 +69,8 @@ class Resource(BaseObject):
                     "This resource is not static, you can't upload a file. "
                     "To modify the URL it points to, please use the `url` field in the payload."
                 )
-            logging.info(f"⬆️ Posting file {file_to_upload} into {self.uri}")
+            if self._client.verbose:
+                logging.info(f"⬆️ Posting file {file_to_upload} into {self.uri}")
             try:
                 r = self._client.session.post(
                     f"{self.uri}upload/",
@@ -158,7 +159,8 @@ class ResourceCreator(Creator):
             payload["dataset"] = {"class": "Dataset", "id": dataset_id}
         else:
             url = f"{self._client.base_url}/api/1/datasets/{dataset_id}/resources/"
-        logging.info(f"🆕 Creating '{payload['title']}' for {url}")
+        if self._client.verbose:
+            logging.info(f"🆕 Creating '{payload['title']}' for {url}")
         if "filetype" not in payload:
             payload.update({"filetype": "remote"})
         if "type" not in payload:
@@ -191,7 +193,8 @@ class ResourceCreator(Creator):
         url = f"{self._client.base_url}/api/1/datasets/{dataset_id}/upload/"
         if is_communautary:
             url += "community/"
-        logging.info(f"🆕 Creating '{payload['title']}' for {file_to_upload}")
+        if self._client.verbose:
+            logging.info(f"🆕 Creating '{payload['title']}' for {file_to_upload}")
         r = self._client.session.post(url, files={"file": open(file_to_upload, "rb")})
         r.raise_for_status()
         metadata = r.json()

--- a/datagouv/resource.py
+++ b/datagouv/resource.py
@@ -85,7 +85,7 @@ class Resource(BaseObject):
             try:
                 r.raise_for_status()
             except Exception as e:
-                raise httpx.HTTPStatusError(r.text) from e
+                raise Exception(r.text) from e
         return super().update(payload)
 
     @property
@@ -112,7 +112,7 @@ class Resource(BaseObject):
             try:
                 r.raise_for_status()
             except Exception as e:
-                raise httpx.HTTPStatusError(r.text) from e
+                raise Exception(r.text) from e
             with open(path, "wb") as f:
                 for chunk in r.iter_bytes(chunk_size=chunk_size):
                     f.write(chunk)
@@ -122,7 +122,7 @@ class Resource(BaseObject):
         try:
             r.raise_for_status()
         except Exception as e:
-            raise httpx.HTTPStatusError(r.text) from e
+            raise Exception(r.text) from e
         return r.json()
 
     @simple_connection_retry
@@ -178,7 +178,7 @@ class ResourceCreator(Creator):
         try:
             r.raise_for_status()
         except Exception as e:
-            raise httpx.HTTPStatusError(r.text) from e
+            raise Exception(r.text) from e
         metadata = r.json()
         return Resource(
             metadata["id"], dataset_id=dataset_id, _client=self._client, _from_response=metadata
@@ -211,7 +211,7 @@ class ResourceCreator(Creator):
         try:
             r.raise_for_status()
         except Exception as e:
-            raise httpx.HTTPStatusError(r.text) from e
+            raise Exception(r.text) from e
         metadata = r.json()
         resource_id = metadata["id"]
         r = Resource(

--- a/datagouv/topic.py
+++ b/datagouv/topic.py
@@ -93,7 +93,8 @@ class TopicCreator(Creator):
     @simple_connection_retry
     def create(self, payload: dict) -> Topic:
         assert_auth(self._client)
-        logging.info(f"Creating topic '{payload['name']}'")
+        if self._client.verbose:
+            logging.info(f"Creating topic '{payload['name']}'")
         r = self._client.session.post(f"{self._client.base_url}/api/2/topics/", json=payload)
         r.raise_for_status()
         metadata = r.json()

--- a/datagouv/topic.py
+++ b/datagouv/topic.py
@@ -99,6 +99,6 @@ class TopicCreator(Creator):
         try:
             r.raise_for_status()
         except Exception as e:
-            raise httpx.HTTPStatusError(r.text) from e
+            raise Exception(r.text) from e
         metadata = r.json()
         return Topic(metadata["id"], _client=self._client, _from_response=metadata)

--- a/datagouv/topic.py
+++ b/datagouv/topic.py
@@ -96,6 +96,9 @@ class TopicCreator(Creator):
         if self._client.verbose:
             logging.info(f"Creating topic '{payload['name']}'")
         r = self._client.session.post(f"{self._client.base_url}/api/2/topics/", json=payload)
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except Exception as e:
+            raise httpx.HTTPStatusError(r.text) from e
         metadata = r.json()
         return Topic(metadata["id"], _client=self._client, _from_response=metadata)


### PR DESCRIPTION
- allow to mute the `Client` (no more logs)
- raise more explicit status errors, passing the response's text as a message