### PR TITLE
Better downloaded file name

### DIFF
--- a/datagouv/resource.py
+++ b/datagouv/resource.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+import re
 
 import httpx
 
@@ -101,9 +102,29 @@ class Resource(BaseObject):
             self._dataset = dataset
         return self._dataset
 
-    def download(self, path: Path | str | None = None, chunk_size: int = 8192, **kwargs):
+    def download(self, path: Path | str | None = None, chunk_size: int = 8192, **kwargs) -> Path:
+        """Download the resource into the specified path (or the best found path if not specified).
+        Return the path as a pathlib.Path object"""
         if path is None:
-            path = Path(f"{self.id}.{self.format}")
+            found = re.findall("[^/]+$", self.url)
+            if found and "." in found[0]:
+                # url seems to be ending with the file's name, we use it
+                path = Path(found[0])
+            else:
+                head = self._client.session.head(self.url)
+                if head.status_code == 200 and head.headers.get("content-disposition"):
+                    # check if the headers indicate a filename 
+                    found = re.findall(
+                        r'filename\*?=\"?(?P<filename>[^;\"]+)\"?',
+                        head.headers["content-disposition"],
+                    )
+                    if found:
+                        path = Path(found[0])
+                if path is None and self.format is not None:
+                    # fall back on <resource_id>.<format> if possible 
+                    path = Path(f"{self.id}.{self.format}")
+                if path is None:
+                    raise ValueError("Could not build a good file name, please specify the `path` argument")
         if isinstance(path, str):
             path = Path(path)
         # Ensure parent directory exists
@@ -116,6 +137,7 @@ class Resource(BaseObject):
             with open(path, "wb") as f:
                 for chunk in r.iter_bytes(chunk_size=chunk_size):
                     f.write(chunk)
+        return path
 
     def get_api2_metadata(self) -> dict:
         r = self._client.session.get(f"{self._client.base_url}/api/2/datasets/resources/{self.id}/")

--- a/datagouv/resource.py
+++ b/datagouv/resource.py
@@ -1,6 +1,6 @@
 import logging
-from pathlib import Path
 import re
+from pathlib import Path
 
 import httpx
 
@@ -113,18 +113,20 @@ class Resource(BaseObject):
             else:
                 head = self._client.session.head(self.url)
                 if head.status_code == 200 and head.headers.get("content-disposition"):
-                    # check if the headers indicate a filename 
+                    # check if the headers indicate a filename
                     found = re.findall(
-                        r'filename\*?=\"?(?P<filename>[^;\"]+)\"?',
+                        r"filename\*?=\"?(?P<filename>[^;\"]+)\"?",
                         head.headers["content-disposition"],
                     )
                     if found:
                         path = Path(found[0])
                 if path is None and self.format is not None:
-                    # fall back on <resource_id>.<format> if possible 
+                    # fall back on <resource_id>.<format> if possible
                     path = Path(f"{self.id}.{self.format}")
                 if path is None:
-                    raise ValueError("Could not build a good file name, please specify the `path` argument")
+                    raise ValueError(
+                        "Could not build a good file name, please specify the `path` argument"
+                    )
         if isinstance(path, str):
             path = Path(path)
         # Ensure parent directory exists

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import json
 import re
+from copy import deepcopy
 
 import pytest
 
@@ -81,7 +82,7 @@ def static_resource_api1_call(httpx_mock):
 
 @pytest.fixture
 def remote_resource_api1_call(httpx_mock):
-    remote_metadata = resource_metadata_api1
+    remote_metadata = deepcopy(resource_metadata_api1)
     remote_metadata["filetype"] = "remote"
     remote_metadata["url"] = "https://example.com/file.csv"
     httpx_mock.add_response(

--- a/tests/resource_metadata_api1.json
+++ b/tests/resource_metadata_api1.json
@@ -13,7 +13,7 @@
     "analysis:mime-type": "text/plain",
     "analysis:parsing:finished_at": "2025-04-07T05:06:01.573747+00:00",
     "analysis:parsing:parquet_size": 832285,
-    "analysis:parsing:parquet_url": "https://object.files.data.gouv.fr/hydra-parquet/hydra-parquet/273b903392463f4f146f5e066cc20c93.parquet",
+    "analysis:parsing:parquet_url": "https://object.files.data.gouv.fr/hydra-parquet/hydra-parquet/aaaaaaaa-1111-bbbb-2222-cccccccccccc.parquet",
     "analysis:parsing:started_at": "2025-04-07T05:06:00.013919+00:00",
     "check:available": true,
     "check:date": "2024-12-10T06:11:06.062000",
@@ -26,18 +26,18 @@
   "filetype": "file",
   "format": "csv",
   "harvest": null,
-  "id": "322d1475-f36a-472d-97ce-d218c8f79092",
+  "id": "aaaaaaaa-1111-bbbb-2222-cccccccccccc",
   "internal": {
     "created_at_internal": "2024-12-10T06:11:04.222000+00:00",
     "last_modified_internal": "2025-04-07T08:15:26.421000+00:00"
   },
   "last_modified": "2025-04-07T08:15:26.421000+00:00",
-  "latest": "https://www.data.gouv.fr/fr/datasets/r/322d1475-f36a-472d-97ce-d218c8f79092",
+  "latest": "https://www.data.gouv.fr/fr/datasets/r/aaaaaaaa-1111-bbbb-2222-cccccccccccc",
   "metrics": {
     "views": 379
   },
   "mime": "text/csv",
-  "preview_url": "https://explore.data.gouv.fr/fr/resources/322d1475-f36a-472d-97ce-d218c8f79092",
+  "preview_url": "https://explore.data.gouv.fr/fr/resources/aaaaaaaa-1111-bbbb-2222-cccccccccccc",
   "schema": null,
   "title": "export-dataservice-20250407-061526.csv",
   "type": "main",

--- a/tests/resource_metadata_api2.json
+++ b/tests/resource_metadata_api2.json
@@ -1,13 +1,13 @@
 {
   "resource": {
-    "id": "322d1475-f36a-472d-97ce-d218c8f79092",
+    "id": "aaaaaaaa-1111-bbbb-2222-cccccccccccc",
     "title": "export-dataservice-20250407-061526.csv",
     "description": null,
     "filetype": "file",
     "type": "main",
     "format": "csv",
     "url": "https://static.data.gouv.fr/resources/catalogue-des-donnees-de-data-gouv-fr/20250407-061526/export-dataservice-20250407-061526.csv",
-    "latest": "https://www.data.gouv.fr/fr/datasets/r/322d1475-f36a-472d-97ce-d218c8f79092",
+    "latest": "https://www.data.gouv.fr/fr/datasets/r/aaaaaaaa-1111-bbbb-2222-cccccccccccc",
     "checksum": {
       "type": "sha1",
       "value": "0d7bb1d30a853949fb522fb7f8b330cbb9cf38c5"
@@ -34,10 +34,10 @@
       "analysis:last-modified-detection": "last-modified-header",
       "analysis:parsing:started_at": "2025-04-07T05:06:00.013919+00:00",
       "analysis:parsing:finished_at": "2025-04-07T05:06:01.573747+00:00",
-      "analysis:parsing:parquet_url": "https://object.files.data.gouv.fr/hydra-parquet/hydra-parquet/273b903392463f4f146f5e066cc20c93.parquet",
+      "analysis:parsing:parquet_url": "https://object.files.data.gouv.fr/hydra-parquet/hydra-parquet/aaaaaaaa-1111-bbbb-2222-cccccccccccc.parquet",
       "analysis:parsing:parquet_size": 832285
     },
-    "preview_url": "https://explore.data.gouv.fr/fr/resources/322d1475-f36a-472d-97ce-d218c8f79092",
+    "preview_url": "https://explore.data.gouv.fr/fr/resources/aaaaaaaa-1111-bbbb-2222-cccccccccccc",
     "schema": null,
     "internal": {
       "created_at_internal": "2024-12-10T06:11:04.222000+00:00",

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -116,8 +116,7 @@ def test_resource_download(remote_resource_api1_call, file_name, custom_url, hea
         headers=headers,
         is_reusable=True,
     )
-    r.download(file_name)
-    local_name = file_name or (r.url.split("/")[-1] if not custom_url else "file.csv")
+    local_name = r.download(file_name)
     with open(local_name, "r") as f:
         rows = f.readlines()
     assert rows[0] == "a,b,c\n"

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -105,7 +105,7 @@ def test_resource_download(remote_resource_api1_call, file_name, httpx_mock):
         content=b"a,b,c\n1,2,3",
     )
     r.download(file_name)
-    local_name = file_name or f"{r.id}.{r.format}"
+    local_name = file_name or r.url.split("/")[-1]
     with open(local_name, "r") as f:
         rows = f.readlines()
     assert rows[0] == "a,b,c\n"

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -99,16 +99,14 @@ def test_resource_no_fetch():
             None,
             "https://api.insee.fr/melodi/file/DS_ESTIMATION_POPULATION/DS_ESTIMATION_POPULATION_CSV_FR",
             {
-                "content-length": "100", "content-disposition":
-                'inline; filename="file.csv"',
+                "content-length": "100",
+                "content-disposition": 'inline; filename="file.csv"',
             },
         ),
         (None, None, {}),
     ],
 )
-def test_resource_download(
-    remote_resource_api1_call, file_name, custom_url, headers, httpx_mock
-):
+def test_resource_download(remote_resource_api1_call, file_name, custom_url, headers, httpx_mock):
     r = Client().resource(RESOURCE_ID, dataset_id=DATASET_ID)
     if custom_url:
         r.url = custom_url
@@ -119,13 +117,7 @@ def test_resource_download(
         is_reusable=True,
     )
     r.download(file_name)
-    local_name = (
-        file_name or (
-            r.url.split("/")[-1]
-            if not custom_url
-            else "file.csv"
-        )
-    )
+    local_name = file_name or (r.url.split("/")[-1] if not custom_url else "file.csv")
     with open(local_name, "r") as f:
         rows = f.readlines()
     assert rows[0] == "a,b,c\n"

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -113,7 +113,12 @@ def test_resource_no_fetch():
     ],
 )
 def test_resource_download(
-    remote_resource_api1_call, file_name, custom_url, headers, expected_name, httpx_mock,
+    remote_resource_api1_call,
+    file_name,
+    custom_url,
+    headers,
+    expected_name,
+    httpx_mock,
 ):
     r = Client().resource(RESOURCE_ID, dataset_id=DATASET_ID)
     if custom_url:

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -92,9 +92,9 @@ def test_resource_no_fetch():
 
 
 @pytest.mark.parametrize(
-    "file_name, custom_url, headers",
+    "file_name, custom_url, headers, expected_name",
     [
-        ("my_file.csv", None, {}),
+        ("my_file.csv", None, {}, "my_file.csv"),
         (
             None,
             "https://api.insee.fr/melodi/file/DS_ESTIMATION_POPULATION/DS_ESTIMATION_POPULATION_CSV_FR",
@@ -102,21 +102,36 @@ def test_resource_no_fetch():
                 "content-length": "100",
                 "content-disposition": 'inline; filename="file.csv"',
             },
+            "file.csv",
         ),
-        (None, None, {}),
+        (
+            None,
+            "https://api.insee.fr/melodi/file/DS_ESTIMATION_POPULATION/DS_ESTIMATION_POPULATION_CSV_FR",
+            {},
+            f"{RESOURCE_ID}.csv",
+        ),
     ],
 )
-def test_resource_download(remote_resource_api1_call, file_name, custom_url, headers, httpx_mock):
+def test_resource_download(
+    remote_resource_api1_call, file_name, custom_url, headers, expected_name, httpx_mock,
+):
     r = Client().resource(RESOURCE_ID, dataset_id=DATASET_ID)
     if custom_url:
         r.url = custom_url
+        httpx_mock.add_response(
+            method="HEAD",
+            url=r.url,
+            status_code=200,
+            headers=headers,
+        )
     httpx_mock.add_response(
+        method="GET",
         url=r.url,
+        status_code=200,
         content=b"a,b,c\n1,2,3",
-        headers=headers,
-        is_reusable=True,
     )
     local_name = r.download(file_name)
+    assert local_name.as_posix() == expected_name
     with open(local_name, "r") as f:
         rows = f.readlines()
     assert rows[0] == "a,b,c\n"


### PR DESCRIPTION
If the download path is not specified, we try to get the best path from:
- the URL
- the `content-disposition` header

Otherwise we fall back on `<resource_id>.<format>` if `format` is available