### PR TITLE
chore: Update Python version requirement to include 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "httpx>=0.28.1,<1",
     "tenacity>=9.0.0,<10",
 ]
-requires-python = ">=3.10,<=3.14"
+requires-python = ">=3.10,<3.15"
 license = "MIT"
 readme = "README.md"
 keywords = ["api", "wrapper", "datagouv"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "httpx>=0.28.1,<1",
     "tenacity>=9.0.0,<10",
 ]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<=3.14"
 license = "MIT"
 readme = "README.md"
 keywords = ["api", "wrapper", "datagouv"]


### PR DESCRIPTION
Requires "<3.15" instead of "<3.14"