### PR TITLE
Make `BaseObject` abstract

### DIFF
--- a/datagouv/base_object.py
+++ b/datagouv/base_object.py
@@ -20,6 +20,8 @@ class BaseObject:
     _attributes: list[str] = []
 
     def __init__(self, id: str, _client: Client = Client()):
+        if self.__class__.__name__ == "BaseObject":
+            raise TypeError("BaseObject is an abstract class, it cannot be instanciated")
         self.id = id
         self._client = _client
         self._base_metrics_url = (

--- a/tests/test_base_object.py
+++ b/tests/test_base_object.py
@@ -1,0 +1,8 @@
+import pytest
+
+from datagouv.base_object import BaseObject
+
+
+def test_not_instanciable():
+    with pytest.raises(TypeError):
+        BaseObject("a")


### PR DESCRIPTION
Originally wanted to used `abc.ABC` but it required to create an `abstractmethod` there is none currently (so quite a bit of useless code). This syntax feels fair