### PR TITLE
feat(client): make the client optional when installing the package

### DIFF
--- a/datagouv/_cli_entry.py
+++ b/datagouv/_cli_entry.py
@@ -1,0 +1,10 @@
+import sys
+
+
+def main():
+    try:
+        from datagouv.cli import app
+    except ImportError:
+        print("CLI requires the [cli] extra: pip install datagouv_client[cli]")
+        sys.exit(1)
+    app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = [{ name = "Etalab", email = "opendatateam@data.gouv.fr" }]
 dependencies = [
     "httpx>=0.28.1,<1",
     "tenacity>=9.0.0,<10",
-    "typer>=0.25.0,<1",
 ]
 requires-python = ">=3.10,<3.15"
 license = "MIT"
@@ -14,8 +13,10 @@ readme = "README.md"
 keywords = ["api", "wrapper", "datagouv"]
 
 [project.optional-dependencies]
+cli = [
+    "typer>=0.25.0,<1",
+]
 dev = [
-    "httpx>=0.28.1,<1",
     "pytest-httpx>=0.35.0,<1",
     "ruff>=0.11.2",
 ]
@@ -42,4 +43,4 @@ lint = { extend-select = ["I"] } # ["I"] is to also sort imports with an isort r
 line-length = 100
 
 [project.scripts]
-datagouv = "datagouv.cli:app"
+datagouv = "datagouv._cli_entry:main"

--- a/uv.lock
+++ b/uv.lock
@@ -61,12 +61,13 @@ source = { editable = "." }
 dependencies = [
     { name = "httpx" },
     { name = "tenacity" },
-    { name = "typer" },
 ]
 
 [package.optional-dependencies]
+cli = [
+    { name = "typer" },
+]
 dev = [
-    { name = "httpx" },
     { name = "pytest-httpx" },
     { name = "ruff" },
 ]
@@ -74,13 +75,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1,<1" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.1,<1" },
     { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.35.0,<1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.2" },
     { name = "tenacity", specifier = ">=9.0.0,<10" },
-    { name = "typer", specifier = ">=0.25.0,<1" },
+    { name = "typer", marker = "extra == 'cli'", specifier = ">=0.25.0,<1" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["cli", "dev"]
 
 [[package]]
 name = "exceptiongroup"


### PR DESCRIPTION
Une proposition pour rendre le client optionnel afin de réduire les dépendances lorsque l'on a besoin uniquement de la librairie.

```bash
❯ uv sync
❯ uv run datagouv
CLI requires the [cli] extra: pip install datagouv_client[cli]

❯ uv sync --extra cli
❯ uv run datagouv
Usage: datagouv [OPTIONS] COMMAND [ARGS]...
Try 'datagouv --help' for help.
╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Missing command.                                                                                                                                                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

Avec pip cela donne : 
```bash
pip install datagouv-client
pip install datagouv-client[cli]
```

Si cela ne fait pas parti de la vision du package car le client sera par exemple l'usage premier de l'outil n'hésitez pas à close l'isssue bien entendu ! 