### PR TITLE
Separate object creation from object instanciation in the Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ dataset.sort_resources(by="title.asc")  # the expected syntax is <field>.<order>
 
 With an authenticated client, you are also allowed to create datasets and resources on the environment you specified:
 ```python
-dataset = client.dataset().create(
+dataset = client.create_dataset(
     {
         "title": "New dataset",
         "description": "A description is required",
@@ -216,14 +216,14 @@ You have two options to create a resource (of any type):
 - from the client itself, by specifying the id of the dataset you want to include it into (you must have the rights on the dataset):
 ```python
 # to create a static resource from a file
-resource = client.resource().create_static(
+resource = client.create_static_resource(
     file_to_upload="path/to/your/file.txt",
     payload={"title": "New static resource"},
     dataset_id="5d13a8b6634f41070a43dff3",
 )  # this creates a static resource with the values you specified, and instantiates a Resource
 
 # to create a remote resource from an url
-resource = client.resource().create_remote(
+resource = client.create_remote_resource(
     payload={"url": "http://example.com/file.txt", "title": "New remote resource"},
     dataset_id="5d13a8b6634f41070a43dff3",
 )  # this creates a remote resource with the values you specified, and instantiates a Resource

--- a/datagouv/api/client.py
+++ b/datagouv/api/client.py
@@ -36,37 +36,45 @@ class Client:
             self.session.headers.update({"X-API-KEY": api_key})
 
     @classmethod
-    def _env_sanity(cls, environment: str):
+    def _env_sanity(cls, environment: str) -> None:
         if environment not in cls._envs:
             raise ValueError(f"`environment` must be in {list(cls._envs)}")
 
-    def resource(self, id: str | None = None, **kwargs):
-        from datagouv.api.resource import Resource, ResourceCreator
+    def resource(self, id: str, **kwargs) -> "Resource":
+        from datagouv.api.resource import Resource
+        return Resource(id, _client=self, **kwargs)
 
-        if id:
-            return Resource(id, _client=self, **kwargs)
-        return ResourceCreator(_client=self)
+    def create_remote_resource(self, payload: dict, dataset_id: str, is_communautary: bool = False) -> "Resource":
+        from datagouv.api.resource import ResourceCreator
+        return ResourceCreator(_client=self).create_remote(payload, dataset_id, is_communautary=is_communautary)
 
-    def dataset(self, id: str | None = None, **kwargs):
-        from datagouv.api.dataset import Dataset, DatasetCreator
+    def create_static_resource(self, file_to_upload: str, payload: dict, dataset_id: str, is_communautary: bool = False) -> "Resource":
+        from datagouv.api.resource import ResourceCreator
+        return ResourceCreator(_client=self).create_static(file_to_upload, payload, dataset_id, is_communautary=is_communautary)
 
-        if id:
-            return Dataset(id, _client=self, **kwargs)
-        return DatasetCreator(_client=self)
+    def dataset(self, id: str, **kwargs) -> "Dataset":
+        from datagouv.api.dataset import Dataset
+        return Dataset(id, _client=self, **kwargs)
 
-    def topic(self, id: str | None = None, **kwargs):
-        from datagouv.api.topic import Topic, TopicCreator
+    def create_dataset(self, payload: dict) -> "Dataset":
+        from datagouv.api.dataset import DatasetCreator
+        return DatasetCreator(_client=self).create(payload=payload)
 
-        if id:
-            return Topic(id, _client=self, **kwargs)
-        return TopicCreator(_client=self)
+    def topic(self, id: str, **kwargs) -> "Topic":
+        from datagouv.api.topic import Topic
+        return Topic(id, _client=self, **kwargs)
 
-    def organization(self, id: str | None = None, **kwargs):
-        from datagouv.api.organization import Organization, OrganizationCreator
+    def create_topic(self, payload: dict) -> "Topic":
+        from datagouv.api.topic import TopicCreator
+        return TopicCreator(_client=self).create(payload=payload)
 
-        if id:
-            return Organization(id, _client=self, **kwargs)
-        return OrganizationCreator(_client=self)
+    def organization(self, id: str, **kwargs) -> "Organization":
+        from datagouv.api.organization import Organization
+        return Organization(id, _client=self, **kwargs)
+
+    def create_organization(self, payload: dict) -> "Organization":
+        from datagouv.api.organization import OrganizationCreator
+        return OrganizationCreator(_client=self).create(payload=payload)
 
     def get_all_from_api_query(
         self,

--- a/datagouv/api/client.py
+++ b/datagouv/api/client.py
@@ -48,6 +48,7 @@ class Client:
     def create_remote_resource(
         self, payload: dict, dataset_id: str, is_communautary: bool = False
     ) -> "Resource":
+        """Create a resource that references a data stored somewhere else on the internet."""
         from datagouv.api.resource import ResourceCreator
 
         return ResourceCreator(_client=self).create_remote(
@@ -57,6 +58,7 @@ class Client:
     def create_static_resource(
         self, file_to_upload: str, payload: dict, dataset_id: str, is_communautary: bool = False
     ) -> "Resource":
+        """Create a resource by uploading a file on datagouv storage."""
         from datagouv.api.resource import ResourceCreator
 
         return ResourceCreator(_client=self).create_static(

--- a/datagouv/api/client.py
+++ b/datagouv/api/client.py
@@ -42,38 +42,55 @@ class Client:
 
     def resource(self, id: str, **kwargs) -> "Resource":
         from datagouv.api.resource import Resource
+
         return Resource(id, _client=self, **kwargs)
 
-    def create_remote_resource(self, payload: dict, dataset_id: str, is_communautary: bool = False) -> "Resource":
+    def create_remote_resource(
+        self, payload: dict, dataset_id: str, is_communautary: bool = False
+    ) -> "Resource":
         from datagouv.api.resource import ResourceCreator
-        return ResourceCreator(_client=self).create_remote(payload, dataset_id, is_communautary=is_communautary)
 
-    def create_static_resource(self, file_to_upload: str, payload: dict, dataset_id: str, is_communautary: bool = False) -> "Resource":
+        return ResourceCreator(_client=self).create_remote(
+            payload, dataset_id, is_communautary=is_communautary
+        )
+
+    def create_static_resource(
+        self, file_to_upload: str, payload: dict, dataset_id: str, is_communautary: bool = False
+    ) -> "Resource":
         from datagouv.api.resource import ResourceCreator
-        return ResourceCreator(_client=self).create_static(file_to_upload, payload, dataset_id, is_communautary=is_communautary)
+
+        return ResourceCreator(_client=self).create_static(
+            file_to_upload, payload, dataset_id, is_communautary=is_communautary
+        )
 
     def dataset(self, id: str, **kwargs) -> "Dataset":
         from datagouv.api.dataset import Dataset
+
         return Dataset(id, _client=self, **kwargs)
 
     def create_dataset(self, payload: dict) -> "Dataset":
         from datagouv.api.dataset import DatasetCreator
+
         return DatasetCreator(_client=self).create(payload=payload)
 
     def topic(self, id: str, **kwargs) -> "Topic":
         from datagouv.api.topic import Topic
+
         return Topic(id, _client=self, **kwargs)
 
     def create_topic(self, payload: dict) -> "Topic":
         from datagouv.api.topic import TopicCreator
+
         return TopicCreator(_client=self).create(payload=payload)
 
     def organization(self, id: str, **kwargs) -> "Organization":
         from datagouv.api.organization import Organization
+
         return Organization(id, _client=self, **kwargs)
 
     def create_organization(self, payload: dict) -> "Organization":
         from datagouv.api.organization import OrganizationCreator
+
         return OrganizationCreator(_client=self).create(payload=payload)
 
     def get_all_from_api_query(

--- a/datagouv/api/resource.py
+++ b/datagouv/api/resource.py
@@ -286,6 +286,7 @@ class ResourceCreator(Creator):
         dataset_id: str | None = None,
         is_communautary: bool = False,
     ) -> Resource:
+        """Create a resource that references a data stored somewhere else on the internet."""
         if dataset_id and self.__class__.__name__ == "Dataset":
             raise ValueError(
                 "When creating a resource from a dataset, you should't specify a dataset_id"
@@ -325,6 +326,7 @@ class ResourceCreator(Creator):
         dataset_id: str | None = None,
         is_communautary: bool = False,
     ) -> Resource:
+        """Create a resource by uploading a file on datagouv storage."""
         if dataset_id and self.__class__.__name__ == "Dataset":
             raise ValueError(
                 "When creating a resource from a dataset, you should't specify a dataset_id"

--- a/datagouv/commands/dataset.py
+++ b/datagouv/commands/dataset.py
@@ -49,7 +49,7 @@ def create(
     if organization_id:
         d = client.organization(organization_id, fetch=False).create_dataset(payload)
     else:
-        d = client.dataset().create(payload | {"owner": owner_id})
+        d = client.create_dataset(payload | {"owner": owner_id})
     typer.echo(f"Dataset created successfully ✓ id is {d.id}")
 
 

--- a/datagouv/commands/organization.py
+++ b/datagouv/commands/organization.py
@@ -38,7 +38,7 @@ def create(
     for item in set:
         key, value = item.split("=", maxsplit=1)
         payload[key] = value
-    o = client.organization().create(payload)
+    o = client.create_organization(payload)
     typer.echo(f"Organization created successfully ✓ id is {o.id}")
 
 

--- a/datagouv/commands/topic.py
+++ b/datagouv/commands/topic.py
@@ -48,7 +48,7 @@ def create(
     for item in set:
         key, value = item.split("=", maxsplit=1)
         payload[key] = value
-    t = client.topic().create(payload)
+    t = client.create_topic(payload)
     typer.echo(f"Topic created successfully ✓ id is : {t.id}")
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,11 +30,17 @@ def test_client_types(args):
                 "_authenticated",
                 "_envs",
                 "base_url",
-                "dataset",
                 "get_all_from_api_query",
-                "resource",
                 "session",
-            ]
+            ] + [
+                prefix + obj
+                for prefix in ["create_", ""]
+                for obj in [
+                    "dataset",
+                    "organization",
+                    "topic",
+                ]
+            ] + ["create_remote_resource", "create_static_resource"]
         )
         assert client.base_url == f"https://{client._envs[env]}.data.gouv.fr"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -32,7 +32,8 @@ def test_client_types(args):
                 "base_url",
                 "get_all_from_api_query",
                 "session",
-            ] + [
+            ]
+            + [
                 prefix + obj
                 for prefix in ["create_", ""]
                 for obj in [
@@ -40,7 +41,8 @@ def test_client_types(args):
                     "organization",
                     "topic",
                 ]
-            ] + ["create_remote_resource", "create_static_resource"]
+            ]
+            + ["create_remote_resource", "create_static_resource"]
         )
         assert client.base_url == f"https://{client._envs[env]}.data.gouv.fr"
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -7,13 +7,12 @@ import pytest
 from conftest import DATASET_ID, OWNER_ID, dataset_metadata
 
 from datagouv.api.client import Client
-from datagouv.api.dataset import Dataset, DatasetCreator
+from datagouv.api.dataset import Dataset
 from datagouv.api.resource import Resource, ResourceCreator
 from datagouv.utils.base_object import BaseObject
 
 
 def test_dataset_instance(dataset_api_call):
-    assert isinstance(Client().dataset(), DatasetCreator)
     assert isinstance(Client().dataset(DATASET_ID), Dataset)
 
 
@@ -43,7 +42,7 @@ def test_dataset_attributes_and_methods(dataset_api_call):
 def test_authentification_assertion():
     client = Client()
     with pytest.raises(PermissionError):
-        client.dataset().create({"title": "Titre"})
+        client.create_dataset({"title": "Titre"})
     d_from_response = Dataset(DATASET_ID, _from_response=dataset_metadata)
     with pytest.raises(PermissionError):
         d_from_response.delete()
@@ -56,11 +55,11 @@ def test_authentification_assertion():
         with pytest.raises(PermissionError):
             getattr(d_from_response, method)({})
     with pytest.raises(PermissionError):
-        d_from_response.create_static({"path": "path"}, {"title": "Titre"})
+        d_from_response.create_static("path", {"title": "Titre"})
 
     # can't create a resource from a dataset and specify a dataset_id
     with pytest.raises(ValueError):
-        d_from_response.create_static({"path": "path"}, {"title": "Titre"}, dataset_id="aaa")
+        d_from_response.create_static("path", {"title": "Titre"}, dataset_id="aaa")
     with pytest.raises(ValueError):
         d_from_response.create_remote({"title": "Titre"}, dataset_id="aaa")
 
@@ -126,7 +125,7 @@ def test_dataset_create(httpx_mock):
         "organization": "646b7187b50b2a93b1ae3d45",
     }
 
-    created_dataset = client.dataset().create(payload)
+    created_dataset = client.create_dataset(payload)
 
     assert isinstance(created_dataset, Dataset)
     for attr in Dataset._attributes:

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -12,12 +12,11 @@ from conftest import (
 
 from datagouv.api.client import Client
 from datagouv.api.dataset import Dataset
-from datagouv.api.organization import Organization, OrganizationCreator
+from datagouv.api.organization import Organization
 from datagouv.utils.base_object import BaseObject
 
 
 def test_organization_instance(organization_api_call):
-    assert isinstance(Client().organization(), OrganizationCreator)
     assert isinstance(Client().organization(ORGANIZATION_ID), Organization)
 
 
@@ -48,7 +47,7 @@ def test_organization_attributes_and_methods(organization_api_call):
 def test_authentification_assertion():
     client = Client()
     with pytest.raises(PermissionError):
-        client.organization().create({"name": "Nom"})
+        client.create_organization({"name": "Nom"})
     o_from_response = Organization(
         organization_metadata["id"], _from_response=organization_metadata
     )
@@ -105,7 +104,7 @@ def test_organization_create(httpx_mock):
         "description": "A nice description",
     }
 
-    created_organization = client.organization().create(payload)
+    created_organization = client.create_organization(payload)
 
     assert isinstance(created_organization, Organization)
     for attr in Organization._attributes:

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -9,12 +9,11 @@ from conftest import DATASET_ID, RESOURCE_ID, resource_metadata_api1, tabular_ap
 
 from datagouv.api.client import Client
 from datagouv.api.dataset import Dataset
-from datagouv.api.resource import Resource, ResourceCreator
+from datagouv.api.resource import Resource
 from datagouv.utils.base_object import BaseObject
 
 
 def test_resource_instance(static_resource_api2_call):
-    assert isinstance(Client().resource(), ResourceCreator)
     assert isinstance(Client().resource(RESOURCE_ID), Resource)
 
 
@@ -56,9 +55,9 @@ def test_resource_attributes_and_methods(static_resource_api2_call):
 def test_authentification_assertion():
     client = Client()
     with pytest.raises(PermissionError):
-        client.resource().create_static({"path": "path"}, {"title": "Titre"}, DATASET_ID)
+        client.create_static_resource("path", {"title": "Titre"}, DATASET_ID)
     with pytest.raises(PermissionError):
-        client.resource().create_remote({"url": "url", "title": "Titre"}, DATASET_ID)
+        client.create_remote_resource({"url": "url", "title": "Titre"}, DATASET_ID)
     r_from_response = Resource(
         RESOURCE_ID, dataset_id=DATASET_ID, _from_response=resource_metadata_api1
     )
@@ -245,7 +244,7 @@ def test_download_buffer(
     "method,kwargs",
     [
         (
-            "create_static",
+            "create_static_resource",
             {
                 "payload": {"title": "New static resource"},
                 "file_to_upload": "tests/resource_metadata_api1.json",
@@ -253,7 +252,7 @@ def test_download_buffer(
             },
         ),
         (
-            "create_remote",
+            "create_remote_resource",
             {
                 "payload": {"title": "New remote resource"},
                 "dataset_id": DATASET_ID,
@@ -285,7 +284,7 @@ def test_resource_create(httpx_mock, method, kwargs):
 
     client = Client(api_key="test-api-key")
 
-    created_resource = getattr(client.resource(), method)(**kwargs)
+    created_resource = getattr(client, method)(**kwargs)
 
     assert isinstance(created_resource, Resource)
     for attr in Resource._attributes:

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -6,13 +6,12 @@ from conftest import OWNER_ID, TOPIC_ID, elements_metadata, topic_metadata
 from datagouv.api.client import Client
 from datagouv.api.dataset import Dataset
 from datagouv.api.organization import Organization
-from datagouv.api.topic import Topic, TopicCreator
+from datagouv.api.topic import Topic
 from datagouv.utils.base_object import BaseObject
 
 
 def test_dataset_instance(topic_api_call):
     assert isinstance(Client().topic(TOPIC_ID), Topic)
-    assert isinstance(Client().topic(), TopicCreator)
 
 
 def test_topic_attributes_and_methods(topic_api_call):
@@ -77,7 +76,7 @@ def test_topic_no_fetch():
 def test_authentification_assertion():
     client = Client()
     with pytest.raises(PermissionError):
-        client.topic().create({"name": "Test Topic"})
+        client.create_topic({"name": "Test Topic"})
 
 
 def test_topic_create(httpx_mock):
@@ -90,15 +89,14 @@ def test_topic_create(httpx_mock):
     )
 
     client = Client(api_key="test-api-key")
-    topic_creator = client.topic()
 
-    payload = {
-        "name": "Test Topic",
-        "description": "A test topic",
-        "private": False,
-    }
-
-    created_topic = topic_creator.create(payload)
+    created_topic = client.create_topic(
+        payload={
+            "name": "Test Topic",
+            "description": "A test topic",
+            "private": False,
+        }
+    )
 
     assert isinstance(created_topic, Topic)
     for attr in Topic._attributes:


### PR DESCRIPTION
Upon discussion, the Client now has `create_<object>` methods instead of `<object>().create`.
⚠️ This is a breaking change and will require a major release when merged