### PR TITLE
Change how dev depencencies are declared

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run:
           name: Install python dependencies
           command: |
-            uv sync --frozen --extra dev
+            uv sync --frozen --dev
       - save_cache:
           key: << pipeline.parameters.cache-prefix >>-v1-{{ arch }}-{{ checksum "pyproject.toml" }}
           paths:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,8 @@ license = "MIT"
 readme = "README.md"
 keywords = ["api", "wrapper", "datagouv"]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
-    "httpx>=0.28.1,<1",
     "pytest-httpx>=0.35.0,<1",
     "ruff>=0.11.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ dependencies = [
     { name = "typer" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "httpx" },
     { name = "pytest-httpx" },
@@ -74,13 +74,16 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1,<1" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.1,<1" },
-    { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.35.0,<1" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.2" },
     { name = "tenacity", specifier = ">=9.0.0,<10" },
     { name = "typer", specifier = ">=0.25.0,<1" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.28.1,<1" },
+    { name = "pytest-httpx", specifier = ">=0.35.0,<1" },
+    { name = "ruff", specifier = ">=0.11.2" },
+]
 
 [[package]]
 name = "exceptiongroup"


### PR DESCRIPTION
## Why?

The current way of declaring dev dependencies (as `optional dependencies`) provides an `extra` to the PyPI package which is called `dev`, allowing users to install `datagouv_client[dev]` and get pytest and everything, which is not the intended behavior.

Furthermore, developers used to `uv` tooling perform a `uv sync --dev` and don't get development dependencies installed, which is disturbing.

## The solution

[PEP 735](https://peps.python.org/pep-0735/) defined a way of declaring `dependency groups` to address just this use case: we just want some dependencies to be installed only in the context of changing this library.

And it just so happens that `uv`, which is used by this library for its development, [has implemented PEP 735](https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups).

## One more thing

I've seen that `httpx` is declared by as a dependency and as a dev dependency, so I removed the latter.