### PR TITLE
docs: update dev dependency install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Contributions and feedback are welcome! Main guidelines:
 
 Remember to format, lint, and sort imports with [Ruff](https://docs.astral.sh/ruff/) before committing (checks will remind you anyway):
 ```bash
-pip install .[dev]
+uv sync --dev
 ruff check --fix .
 ruff format .
 ```

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Contributions and feedback are welcome! Main guidelines:
 
 Remember to format, lint, and sort imports with [Ruff](https://docs.astral.sh/ruff/) before committing (checks will remind you anyway):
 ```bash
-uv sync --dev
+pip install --group dev .
 ruff check --fix .
 ruff format .
 ```


### PR DESCRIPTION
After #61 moved dev dependencies from optional extras to PEP 735 dependency groups, `pip install .[dev]` no longer installs ruff and other dev tools.
This aligns the Contribution section with the PEP 735 dependency groups install command.