### PR TITLE
fix(client): restore session headers merge for CLI usage

### DIFF
--- a/datagouv/api/client.py
+++ b/datagouv/api/client.py
@@ -27,9 +27,7 @@ class Client:
     ):
         self._env_sanity(environment)
         self.session = niquests.Session(
-            timeout=15,
-            headers=PYTHON_USER_AGENT,
-            **kwargs,
+            **({"timeout": 15, "headers": PYTHON_USER_AGENT} | kwargs)
         )
         self.environment = self._envs[environment]
         self.base_url = f"https://{self.environment}.data.gouv.fr"

--- a/datagouv/api/client.py
+++ b/datagouv/api/client.py
@@ -26,9 +26,7 @@ class Client:
         **kwargs,
     ):
         self._env_sanity(environment)
-        self.session = niquests.Session(
-            **({"timeout": 15, "headers": PYTHON_USER_AGENT} | kwargs)
-        )
+        self.session = niquests.Session(**({"timeout": 15, "headers": PYTHON_USER_AGENT} | kwargs))
         self.environment = self._envs[environment]
         self.base_url = f"https://{self.environment}.data.gouv.fr"
         self.verbose = verbose

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,18 @@ from unittest.mock import Mock, patch
 import pytest
 
 from datagouv import Client, Dataset
+from datagouv.api.client import PYTHON_USER_AGENT
+from datagouv.config import CLI_USER_AGENT
+
+
+def test_client_default_user_agent():
+    client = Client()
+    assert client.session.headers["User-Agent"] == PYTHON_USER_AGENT["User-Agent"]
+
+
+def test_client_cli_user_agent():
+    client = Client(headers=CLI_USER_AGENT)
+    assert client.session.headers["User-Agent"] == CLI_USER_AGENT["User-Agent"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The switch from `httpx` to `niquests` in v0.4.0 broke the CLI, and existing tests didn’t catch it.

Before, the HTTP client was built by merging a defaults dict with caller kwargs:

```
{"timeout": 15, "headers": ...} | kwargs
```

When the CLI passed its own User-Agent, it simply replaced the default — no conflict.

With `niquests`, headers was passed twice: once explicitly on `Session(...)`, and again via `**kwargs` from `load_config()`. That raised a `TypeError `as soon as the client was created, before any API call.

Tests didn’t surface this because they always instantiate the client directly (`Client()`), never through `load_config()`.

This PR restores dict merging for session creation and adds a test for the CLI path.