### PR TITLE
refactor: rename repo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "datagouv_client"
+name = "datagouv-client"
 dynamic = ["version"]
 description = "Wrapper for the data.gouv.fr API"
 authors = [{ name = "Etalab", email = "opendatateam@data.gouv.fr" }]


### PR DESCRIPTION
[PEP 423](https://peps.python.org/pep-0423/) recommends using lowercase names with hyphens for distributions, which is the official normalized format.

This PR updates the package name in pyproject.toml to comply with this standard.

We will also rename the GitHub repository to match. This won't break anything, as GitHub automatically sets up a redirect from the old URL.

**Note regarding PyPI:**
While it is impossible to directly change the project name on PyPI ([https://pypi.org/project/datagouv_client/](https://www.google.com/search?q=https://pypi.org/project/datagouv_client/)), it is already aliased to [https://pypi.org/project/datagouv-client/](https://www.google.com/search?q=https://pypi.org/project/datagouv-client/) for both web access and package installation.